### PR TITLE
45 two admins to deactivate or demote

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -123,3 +123,11 @@
   opacity: 1;
   background-color: var(--grey);
 }
+
+.profile-image-small{
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  border: 1px solid ;
+  margin-right: 3px;
+}

--- a/src/components/ApplicationViews.jsx
+++ b/src/components/ApplicationViews.jsx
@@ -140,15 +140,6 @@ export default function ApplicationViews({ loggedInUser, setLoggedInUser }) {
         </Route>
 
 
-        {/* DELETE LATER */}
-        <Route
-          path="example"
-          element={
-            <AuthorizedRoute loggedInUser={loggedInUser}>
-              <Example />
-            </AuthorizedRoute>
-          }
-        />
         <Route
           path="categories"
           element={

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { NavLink as RRNavLink } from "react-router-dom";
+import { Link, NavLink as RRNavLink } from "react-router-dom";
 import {
   Button,
   Collapse,
@@ -87,6 +87,17 @@ export default function NavBar({ loggedInUser, setLoggedInUser }) {
                 )}
               </Nav>
             </Collapse>
+            <Link
+              className="me-2 text-light text-decoration-none"
+              to={`/userprofiles/${loggedInUser.id}`}
+            >
+              <img
+                className="profile-image-small"
+                src={loggedInUser.imageLocation}
+                alt="profile"
+              />
+              {loggedInUser.firstName} {loggedInUser.lastName}
+            </Link>
             <Button
               color="danger"
               onClick={(e) => {

--- a/src/components/userprofiles/UserProfileItem.jsx
+++ b/src/components/userprofiles/UserProfileItem.jsx
@@ -1,0 +1,89 @@
+import React, { useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import {
+  Badge,
+  Button,
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+} from "reactstrap";
+import { getAdminActionCount } from "../../managers/adminActionManager";
+
+export default function UserProfileItem({
+  profile,
+  onDeactivate,
+  onReactivate,
+  onDeactivateAuthor,
+  refreshUsers,
+}) {
+  const [votes, setVotes] = useState(0);
+
+  useEffect(() => {
+    getAdminActionCount(profile.id, "deactivate").then((votes) =>
+      setVotes(votes)
+    );
+  }, [profile.id]);
+
+  const handleDeactivate = async (userId) => {
+    const updatedVotes = await onDeactivate(userId);
+    setVotes(updatedVotes);
+    refreshUsers();
+  };
+
+  const handleDeactivateAuthor = async (userId) => {
+    await onDeactivateAuthor(userId);
+    const updatedVotes = await getAdminActionCount(userId, "deactivate");
+    setVotes(updatedVotes);
+    refreshUsers();
+  };
+
+  return (
+    <tr>
+      <td>
+        {profile.firstName} {profile.lastName} ({profile.userName})
+      </td>
+      <td>
+        {profile.roles[0] === "Admin" ? (
+          <span>{profile.roles.join(", ")}</span>
+        ) : (
+          <span>Author</span>
+        )}
+      </td>
+      <td>
+        {profile.isActive ? (
+          profile.roles[0] === "Admin" ? (
+            <Button
+              outline
+              color="danger"
+              onClick={async () => {
+                await handleDeactivate(profile.id);
+              }}
+            >
+              Deactivate
+              <Badge className="ms-2" color="danger">
+                Votes: {votes}
+              </Badge>
+            </Button>
+          ) : (
+            <Button
+              color="danger"
+              onClick={async () => {
+                await handleDeactivateAuthor(profile.id);
+              }}
+            >
+              Demote
+            </Button>
+          )
+        ) : (
+          <Button color="success" onClick={() => onReactivate(profile.id)}>
+            Reactivate
+          </Button>
+        )}
+      </td>
+      <td>
+        <Link to={`/userprofiles/${profile.id}`}>Details</Link>
+      </td>
+    </tr>
+  );
+}

--- a/src/components/userprofiles/UserProfilesList.jsx
+++ b/src/components/userprofiles/UserProfilesList.jsx
@@ -3,17 +3,37 @@ import {
   getProfiles,
   deactivateUser,
   reactivateUser,
+  demoteUser,
 } from "../../managers/userProfileManager";
 import { Link } from "react-router-dom";
+import UserProfileItem from "./UserProfileItem";
+import {
+  Button,
+  Container,
+  Table,
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  Alert,
+} from "reactstrap";
+import {
+  executeAdminAction,
+  getAdminActionCount,
+} from "../../managers/adminActionManager";
 
 export default function UserProfileList() {
   const [userProfiles, setUserProfiles] = useState([]);
   const [showInactive, setShowInactive] = useState(false); // Track if inactive users should be shown
+  const [alertVisible, setAlertVisible] = useState(false);
+  const [alertMessage, setAlertMessage] = useState("");
+  const [modalVisible, setModalVisible] = useState(false);
+  const [modalMessage, setModalMessage] = useState("");
+  const [modalAction, setModalAction] = useState(null);
 
-  // Fetch user profiles from the API
-  const getUserProfiles = async () => {
+  // Fetch user profiles from the API and set them in state
+  const getAndSetUsers = async () => {
     try {
-      // Fetch the profiles from the API
       const profiles = await getProfiles();
 
       // Filter profiles based on the `showInactive` state
@@ -37,35 +57,63 @@ export default function UserProfileList() {
 
   // Function to handle deactivating a user with confirmation
   const handleDeactivate = (userId) => {
-    const confirmDeactivation = window.confirm(
-      "Are you sure you want to deactivate this user?"
-    );
-    if (confirmDeactivation) {
-      console.log("Deactivating user:", userId);
-      deactivateUser(userId)
-        .then(() => {
-          console.log("User deactivated, refetching profiles...");
-          getUserProfiles();
-        })
-        .catch((error) => {
-          console.error("Failed to deactivate user:", error);
-        });
-    } else {
-      console.log("Deactivation canceled");
+    setModalMessage("Are you sure you want to deactivate this user?");
+    setModalAction(() => () => executeDeactivation(userId));
+    setModalVisible(true);
+  };
+
+  const executeDeactivation = async (userId) => {
+    try {
+      const data = await executeAdminAction(userId, "deactivate");
+      const updatedVotes = await getAdminActionCount(userId, "deactivate");
+      setAlertMessage(data.message);
+      setAlertVisible(true);
+      setTimeout(() => setAlertVisible(false), 5000);
+
+      await getAndSetUsers();
+      return updatedVotes;
+    } catch (error) {
+      setAlertMessage(error.message);
+      setAlertVisible(true);
+      setTimeout(() => setAlertVisible(false), 5000);
+    } finally {
+      setModalVisible(false);
+    }
+  };
+
+  // Function to handle deactivating an author with confirmation
+  const handleDeactivateAuthor = (userId) => {
+    setModalMessage("Are you sure you want to deactivate this author?");
+    setModalAction(() => () => executeDeactivationAuthor(userId));
+    setModalVisible(true);
+  };
+
+  const executeDeactivationAuthor = async (userId) => {
+    try {
+      await deactivateUser(userId);
+      getAndSetUsers();
+    } catch (error) {
+      console.error("Error deactivating author:", error);
+    } finally {
+      setModalVisible(false);
     }
   };
 
   // Function to handle reactivating a user with confirmation
   const handleReactivate = (userId) => {
-    const confirmReactivation = window.confirm(
-      "Are you sure you want to reactivate this user?"
-    );
-    if (confirmReactivation) {
-      reactivateUser(userId).then(() => {
-        getUserProfiles();
-      });
-    } else {
-      console.log("Reactivation canceled");
+    setModalMessage("Are you sure you want to reactivate this user?");
+    setModalAction(() => () => executeReactivation(userId));
+    setModalVisible(true);
+  };
+
+  const executeReactivation = async (userId) => {
+    try {
+      await reactivateUser(userId);
+      getAndSetUsers();
+    } catch (error) {
+      console.error("Error reactivating user:", error);
+    } finally {
+      setModalVisible(false);
     }
   };
 
@@ -76,37 +124,67 @@ export default function UserProfileList() {
 
   // On component mount, fetch user profiles
   useEffect(() => {
-    getUserProfiles();
+    getAndSetUsers();
   }, [showInactive]); // Re-fetch profiles when `showInactive` changes
 
   return (
-    <>
-      <p>User Profile List</p>
+    <Container>
+      <h2>User Profile List</h2>
 
       {/* Toggle Button */}
-      <button onClick={toggleShowInactive}>
+      <Button className="mb-2" onClick={toggleShowInactive}>
         {showInactive ? "Show Active Users" : "Show Inactive Users"}
-      </button>
+      </Button>
 
-      {/* Display user profiles */}
-      {userProfiles.map((p) => (
-        <p key={p.id}>
-          {p.firstName} {p.lastName} {p.userName}{" "}
-          {p.roles[0] === "Admin" ? (
-            <span>{p.roles.join(", ")}</span>
-          ) : (
-            <span>Author</span>
-          )}
-          {/* Show deactivation or reactivation button based on the user's current status */}
-          {p.isActive === true && (
-            <button onClick={() => handleDeactivate(p.id)}>Deactivate</button>
-          )}
-          {p.isActive === false && (
-            <button onClick={() => handleReactivate(p.id)}>Reactivate</button>
-          )}
-          <Link to={`/userprofiles/${p.id}`}>Details</Link>
-        </p>
-      ))}
-    </>
+      {/* Display user profiles in a table */}
+      <Table striped hover bordered className="table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Role</th>
+            <th>Action</th>
+            <th>Details</th>
+          </tr>
+        </thead>
+        <tbody>
+          {userProfiles.map((p) => (
+            <UserProfileItem
+              key={p.id}
+              profile={p}
+              onDeactivate={handleDeactivate}
+              onReactivate={handleReactivate}
+              onDeactivateAuthor={handleDeactivateAuthor}
+              refreshUsers={getAndSetUsers}
+            />
+          ))}
+        </tbody>
+      </Table>
+
+      {/* Modal for confirmation */}
+      <Modal isOpen={modalVisible} toggle={() => setModalVisible(false)}>
+        <ModalHeader toggle={() => setModalVisible(false)}>
+          Confirmation
+        </ModalHeader>
+        <ModalBody>{modalMessage}</ModalBody>
+        <ModalFooter>
+          <Button color="danger" onClick={modalAction}>
+            Confirm
+          </Button>
+          <Button color="secondary" onClick={() => setModalVisible(false)}>
+            Cancel
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      {/* Alert for deactivation success */}
+      <Alert
+        color="info"
+        isOpen={alertVisible}
+        toggle={() => setAlertVisible(false)}
+        fade={true}
+      >
+        {alertMessage}
+      </Alert>
+    </Container>
   );
 }

--- a/src/managers/adminActionManager.js
+++ b/src/managers/adminActionManager.js
@@ -1,0 +1,37 @@
+export const executeAdminAction = async (userId, actionType) => {
+  const response = await fetch(
+    `/api/AdminAction/execute?userId=${userId}&actionType=${actionType}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const errorMessage = await response.text();
+    throw new Error(errorMessage);
+  }
+
+  return await response.json();
+};
+
+export const getAdminActionCount = async (userId, actionType) => {
+    const response = await fetch(
+        `/api/AdminAction/count?userId=${userId}&actionType=${actionType}`,
+        {
+            method: "GET",
+            headers: {
+                "Content-Type": "application/json",
+            },
+        }
+    );
+
+    if (!response.ok) {
+        const errorMessage = await response.text();
+        throw new Error(errorMessage);
+    }
+
+    return await response.json();
+};


### PR DESCRIPTION
## Description

- Added `<UserProfileItem/>` component for each item in `<UserProfileList/>`
- Added service for admin action items demoting and soft deleting.
- Implemented that service so it takes two admins to demote or soft delete. (`<UserProfileItem/>` `<UserProfileList/>` and `<UserProfileDetails/> affected.`
-  Added indication of who is currently logged in (visible in the `<NavBar/>`)
- Added link to profile of the logged in user via the `<NavBar/>`
- Added styling

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [ ] Other (please describe)
## Checklist:
- [ ] I have read the contributing guidelines.
- [ ] I have tested the changes.
- [ ] I have updated the documentation (if applicable).
- [ ] I have added relevant tests (if applicable).
- [ ] I have checked for any breaking changes.
